### PR TITLE
Fix flaky pre-commit runs in GHA

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,51 +1,19 @@
 name: pre-commit
-
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
-
-
-on: [push]
-
+on:
+  pull_request:
+  push:
+    branches: [main, prod]
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    if: >-
-      !contains(github.event.head_commit.message, 'ci skip') &&
-      (
-        startsWith(github.ref, 'refs/heads') ||
-        github.event.pull_request.draft == false
-      )
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y libcurl4-openssl-dev
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.8"
-          architecture: "x64"
-      - name: Run pre-commit
-        uses: pre-commit/action@v2.0.3
-      - name: Commit files
-        if: failure() && startsWith(github.ref, 'refs/heads')
-        run: |
-          if [[ `git status --porcelain --untracked-files=no` ]]; then
-            git config --local user.email "github-actions[bot]@users.noreply.github.com"
-            git config --local user.name "github-actions[bot]"
-            git checkout -- .github/workflows
-            git commit -m "pre-commit" -a
-          fi
-      - name: Push changes
-        if: failure() && startsWith(github.ref, 'refs/heads')
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-    env:
-      RENV_CONFIG_CACHE_ENABLED: FALSE
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/R/renv
+        key: r-precommit-cache|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,8 @@ repos:
     rev: v0.4.2
     hooks:
     -   id: style-files
-        args: [--style_pkg=styler, --style_fun=tidyverse_style]    
+        args: [--style_pkg=styler, --style_fun=tidyverse_style,
+               --cache-root=styler-perm]
     -   id: roxygenize
     -   id: use-tidy-description
     -   id: lintr
@@ -18,13 +19,18 @@ repos:
     -   id: deps-in-desc
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
-    hooks: 
+    hooks:
     -   id: check-added-large-files
         args: ['--maxkb=200']
     -   id: file-contents-sorter
         files: '^\.Rbuildignore$'
     -   id: end-of-file-fixer
         exclude: '\.Rd'
+    -   id: check-yaml
+    -   id: check-toml
+    -   id: mixed-line-ending
+        args: ['--fix=lf']
+    -   id: trailing-whitespace
 -   repo: https://github.com/pre-commit-ci/pre-commit-ci-config
     rev: v1.6.1
     hooks:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # RtGam (development version)
 
 * CI status in README badges
+* Update pre-commit hooks from template repo to newest version (#25)
 * Implement internal data schema and input validation (#7)
 * Initial CI setup

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 comment:
      layout: "condensed_header, condensed_files, condensed_footer" # add "condensed_" to "header", "files" and "footer"
-      hide_project_coverage: TRUE # set to true
+     hide_project_coverage: TRUE # set to true
 
 coverage:
   status:


### PR DESCRIPTION
When running in GHA, pre-commit randomly struggles to find {styler} and errors out. This issue seems to be coming from a default setting in the template repo and it's happening in other CFA repos too. @kaitejohnson has a suggested fix in cdcgov/wastewater-informed-covid-forecasting#141 and I'm testing it out here.

The new hooks look like they're working well in https://github.com/CDCgov/cfa-gam-rt/pull/25/commits/dc0a465a5a9e782c08a2cc0c33b5537de1785504 and https://github.com/CDCgov/cfa-gam-rt/pull/25/commits/26aada44123027a02443762a6e301bb3558234a5 is able to pick up the cache successfully 🚀 

Closes #24