### PR TITLE
Issue 43: Patch changed data set name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ print(fit)
 ## Project Admin
 
 - Zachary Susswein (@zsusswein)
-- Katelyn Gostic (@gostic)
+- Katelyn Gostic (@kgostic)
 - Sam Abbott (@seabbs)
 
 ------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ print(fit)
 ## Project Admin
 
 - Zachary Susswein (@zsusswein)
-- Katelyn Gostic, PhD (@kgostic)
-- Sam Abbott, PhD (@seabbs)
+- Katelyn Gostic (@gostic)
+- Sam Abbott (@seabbs)
 
 ------------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ This snippet uses the simulated dataset to demonstrate how to use the main model
 library(RtGam)
 
 fit <- RtGam(
-        cases = gostic_toy_rt[["obs_incidence"]],
+        cases = stochastic_sir_rt[["obs_incidence"]],
         # Randomly chosen date
-        reference_date = gostic_toy_rt[["time"]] + as.Date("2023-01-01")
+        reference_date = stochastic_sir_rt[["time"]] + as.Date("2023-01-01")
        )
 print(fit)
 ```


### PR DESCRIPTION
This PR closes issue #43 by renaming the dataset to the new dataset name. 

Looking at the README do we really need to list contributor qualifications after their names and if so why aren't we listing more than just PhDs. I would much rather drop.