### PR TITLE
Use `rlang::caller_arg()` for default arg in checkers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Developer tooling
 
 * Update `{primarycensoreddist}` to `{primarycensored}` to match the name change in the v0.6.0 release (#53)
+* Automatically refer to the argument name in error messages (#51)
 
 # RtGam v0.1.0
 

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -29,10 +29,11 @@ check_vector_length <- function(
   invisible()
 }
 
-check_vectors_equal_length <- function(cases,
-                                       reference_date,
-                                       group,
-                                       call = rlang::caller_env()) {
+check_vectors_equal_length <- function(
+    cases,
+    reference_date,
+    group,
+    call = rlang::caller_env()) {
   if (rlang::is_null(group)) {
     args <- c("cases", "reference_date")
     lengths <- c(length(cases), length(reference_date))
@@ -59,9 +60,10 @@ check_vectors_equal_length <- function(cases,
   invisible()
 }
 
-check_dates_unique <- function(reference_date,
-                               group,
-                               call = rlang::caller_env()) {
+check_dates_unique <- function(
+    reference_date,
+    group,
+    call = rlang::caller_env()) {
   # Two cases:
   ## (1) There are no groups -- need to check that all dates are unique
   ## (2) There **are** groups -- check that dates unique _within each group_
@@ -103,13 +105,14 @@ check_dates_unique <- function(reference_date,
   invisible()
 }
 
-check_required_inputs_provided <- function(cases,
-                                           reference_date,
-                                           group,
-                                           k,
-                                           m,
-                                           backend,
-                                           call = rlang::caller_env()) {
+check_required_inputs_provided <- function(
+    cases,
+    reference_date,
+    group,
+    k,
+    m,
+    backend,
+    call = rlang::caller_env()) {
   rlang::check_required(cases, "cases", call = call)
   rlang::check_required(reference_date, "reference_date", call = call)
   rlang::check_required(group, "group", call = call)
@@ -178,10 +181,11 @@ check_elements_above_min <- function(
   invisible()
 }
 
-check_sums_to_one <- function(x,
-                              arg = rlang::caller_arg(x),
-                              call = rlang::caller_env(),
-                              tol = 1e-8) {
+check_sums_to_one <- function(
+    x,
+    arg = rlang::caller_arg(x),
+    call = rlang::caller_env(),
+    tol = 1e-8) {
   diff <- abs(sum(x) - 1)
   if (diff > tol) {
     cli::cli_abort(
@@ -289,10 +293,11 @@ check_character <- function(
 #'   should never return.
 #' @importFrom rlang abort
 #' @noRd
-throw_type_error <- function(object,
-                             arg_name = rlang::caller_arg(object),
-                             expected_type,
-                             call = rlang::caller_env()) {
+throw_type_error <- function(
+    object,
+    arg_name = rlang::caller_arg(object),
+    expected_type,
+    call = rlang::caller_env()) {
   cli::cli_abort(
     c("{.arg {arg_name}} is {.obj_type_friendly {object}}",
       "i" = "Must be of type {.emph {expected_type}}"

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -1,4 +1,9 @@
-check_vector_length <- function(n, name, min, max, call = rlang::caller_env()) {
+check_vector_length <- function(
+    n,
+    name,
+    min,
+    max,
+    call = rlang::caller_env()) {
   if (!rlang::is_na(min)) {
     if (n < min) {
       cli::cli_abort(
@@ -114,7 +119,10 @@ check_required_inputs_provided <- function(cases,
   invisible()
 }
 
-check_no_missingness <- function(x, arg = "x", call = rlang::caller_env()) {
+check_no_missingness <- function(
+    x,
+    arg = rlang::caller_arg(x),
+    call = rlang::caller_env()) {
   is_missing <- rlang::are_na(x)
 
   if (any(is_missing)) {
@@ -129,7 +137,11 @@ check_no_missingness <- function(x, arg = "x", call = rlang::caller_env()) {
   }
 }
 
-check_elements_below_max <- function(x, arg, max, call = rlang::caller_env()) {
+check_elements_below_max <- function(
+    x,
+    arg = rlang::caller_arg(x),
+    max,
+    call = rlang::caller_env()) {
   # Greater than or equal to 0 or is NA
   is_below_max <- all((x <= max) | is.na(x))
   if (!all(is_below_max)) {
@@ -146,7 +158,11 @@ check_elements_below_max <- function(x, arg, max, call = rlang::caller_env()) {
 }
 
 
-check_elements_above_min <- function(x, arg, min, call = rlang::caller_env()) {
+check_elements_above_min <- function(
+    x,
+    arg = rlang::caller_arg(x),
+    min,
+    call = rlang::caller_env()) {
   # Greater than or equal to 0 or is NA
   is_above_min <- (x >= min) | is.na(x)
   if (!all(is_above_min)) {
@@ -163,7 +179,7 @@ check_elements_above_min <- function(x, arg, min, call = rlang::caller_env()) {
 }
 
 check_sums_to_one <- function(x,
-                              arg = "x",
+                              arg = rlang::caller_arg(x),
                               call = rlang::caller_env(),
                               tol = 1e-8) {
   diff <- abs(sum(x) - 1)
@@ -193,7 +209,10 @@ NULL
 
 #' @rdname type_checker
 #' @noRd
-check_date <- function(x, arg = "x", call = rlang::caller_env()) {
+check_date <- function(
+    x,
+    arg = rlang::caller_arg(x),
+    call = rlang::caller_env()) {
   if ((!rlang::is_integerish(x)) || (!inherits(x, "Date"))) {
     throw_type_error(
       object = x,
@@ -207,7 +226,10 @@ check_date <- function(x, arg = "x", call = rlang::caller_env()) {
 
 #' @rdname type_checker
 #' @noRd
-check_vector <- function(x, arg = "x", call = rlang::caller_env()) {
+check_vector <- function(
+    x,
+    arg = rlang::caller_arg(x),
+    call = rlang::caller_env()) {
   # Lists are bare vectors, but we want truly vanilla vectors
   if (!rlang::is_bare_vector(x) || inherits(x, "list")) {
     throw_type_error(
@@ -222,7 +244,10 @@ check_vector <- function(x, arg = "x", call = rlang::caller_env()) {
 
 #' @rdname type_checker
 #' @noRd
-check_integer <- function(x, arg = "x", call = rlang::caller_env()) {
+check_integer <- function(
+    x,
+    arg = rlang::caller_arg(x),
+    call = rlang::caller_env()) {
   if (!rlang::is_bare_integerish(x)) {
     throw_type_error(
       object = x,
@@ -234,7 +259,10 @@ check_integer <- function(x, arg = "x", call = rlang::caller_env()) {
   invisible()
 }
 
-check_character <- function(x, arg = "x", call = rlang::caller_env()) {
+check_character <- function(
+    x,
+    arg = rlang::caller_arg(x),
+    call = rlang::caller_env()) {
   if (!rlang::is_bare_character(x)) {
     throw_type_error(
       object = x,
@@ -262,7 +290,7 @@ check_character <- function(x, arg = "x", call = rlang::caller_env()) {
 #' @importFrom rlang abort
 #' @noRd
 throw_type_error <- function(object,
-                             arg_name,
+                             arg_name = rlang::caller_arg(object),
                              expected_type,
                              call = rlang::caller_env()) {
   cli::cli_abort(


### PR DESCRIPTION
As detailed in:
https://rlang.r-lib.org/reference/topic-error-call.html#input-checkers-and-caller-arg-

Also standardized the formatting of the calls to have a newline after each arg.

Closes #49
