### PR TITLE
Error R CMD check on NOTE on CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,6 +26,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      RCMDCHECK_ERROR_ON: note
 
     steps:
       - uses: actions/checkout@v4

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Update `{primarycensoreddist}` to `{primarycensored}` to match the name change in the v0.6.0 release (#53)
 * Automatically refer to the argument name in error messages (#51)
 * Add dependabot for GitHub Actions (#55)
+* Error R CMD check for NOTEs when running in CI (#57)
 
 # RtGam v0.1.0
 


### PR DESCRIPTION
Implemented as outline here:
https://rcmdcheck.r-lib.org/reference/rcmdcheck.html

I manually check for NOTEs in CI. It would be easier to have them
automatically trigger alerts for an immediate fix. If at some point
we have a "justified" NOTE and don't want to fix it, I'll remove
the setting.
