### PR TITLE
Set local merge strategy for NEWS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+NEWS.md merge=union

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Update `{primarycensoreddist}` to `{primarycensored}` to match the name change in the v0.6.0 release (#53)
 * Automatically refer to the argument name in error messages (#51)
 * Add dependabot for GitHub Actions (#55)
+* Set default merge strategy for NEWS.md to `union` to limit merge conflicts (#58)
 
 # RtGam v0.1.0
 


### PR DESCRIPTION
The NEWS check is great because I always forget to update NEWS,
but the file also always causes merge conflicts because every PR
is changing the same line.

Here, I'm setting the merge strategy for NEWS.md only to be a
union of the changes in the two files. This gets rid of the merge
conflicts.

It's an imperfect solution because it only works locally. GitHub
can't use the merge strategy and will show the conflict. That's a
pain but a local solution is good enough for me for now.
