### PR TITLE
Auto-convert dates passed as strings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+* Cast dates passed as strings to a `Date` if possible (#67)
+
 ## Bugs
 
 ## Developer tooling

--- a/R/RtGam.R
+++ b/R/RtGam.R
@@ -86,7 +86,7 @@ RtGam <- function(cases,
     m,
     backend
   )
-  validate(cases, reference_date, group, k, m)
+  reference_date <- validate(cases, reference_date, group, k, m)
 
   df <- dataset_creator(cases, reference_date, group, backend)
   formula <- formula_creator(

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -217,6 +217,24 @@ check_date <- function(
     x,
     arg = rlang::caller_arg(x),
     call = rlang::caller_env()) {
+  if (rlang::is_character(x)) {
+    casted <- rlang::try_fetch(
+      as.Date(x),
+      error = function(con) {
+        cli::cli_abort(c(
+          "{.arg {arg}} {.val {x}} could not be automatically cast to date.",
+          "Try explicitly converting with {.fn as.Date}"
+        ))
+      },
+      call = call
+    )
+    cli::cli_alert(c(
+      "Casting {.arg {arg}} {.obj_type_friendly {x}} ",
+      "{.arg {head(x)}} to {.obj_type_friendly {casted}} ",
+      "{.val {stringify_date(head(casted))}}"
+    ))
+    x <- casted
+  }
   if ((!rlang::is_integerish(x)) || (!inherits(x, "Date"))) {
     throw_type_error(
       object = x,
@@ -225,7 +243,7 @@ check_date <- function(
       call = call
     )
   }
-  invisible()
+  invisible(x)
 }
 
 #' @rdname type_checker

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,9 @@
+#' Convert a Date to a YYYY-MM-DD string
+#' @noRd
+stringify_date <- function(d) {
+  if (inherits(d, "Date")) {
+    format(d, "%Y-%m-%d")
+  } else {
+    d
+  }
+}

--- a/R/validate.R
+++ b/R/validate.R
@@ -13,7 +13,7 @@ validate <- function(cases,
                      call = rlang::caller_env()) {
   # Basic type checks
   validate_cases(cases, call)
-  validate_dates(reference_date, "reference_date", call)
+  reference_date <- validate_dates(reference_date, "reference_date", call)
   validate_group(group, call)
   validate_min_dimensionality(k,
     arg = "k",
@@ -32,7 +32,7 @@ validate <- function(cases,
   check_vectors_equal_length(cases, reference_date, group, call)
   check_dates_unique(reference_date, group, call)
 
-  invisible()
+  invisible(reference_date)
 }
 
 validate_cases <- function(cases, call) {
@@ -47,9 +47,9 @@ validate_cases <- function(cases, call) {
 validate_dates <- function(dates, arg, call) {
   arg <- "dates"
   # No vector check because date vector is of type Date
-  check_date(dates, arg, call)
+  dates <- check_date(dates, arg, call)
   check_no_missingness(dates, arg, call)
-  invisible()
+  invisible(dates)
 }
 
 validate_group <- function(group, call) {

--- a/tests/testthat/_snaps/RtGam.md
+++ b/tests/testthat/_snaps/RtGam.md
@@ -1,0 +1,7 @@
+# Can autofix dates and fit model
+
+    Code
+      fit <- RtGam(cases, stringify_date(dates), group)
+    Message
+      > Casting `dates` a character vector `2023-01-02`, `2023-01-03`, `2023-01-04`, `2023-01-05`, `2023-01-06`, and `2023-01-07` to a <Date> object "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-05", "2023-01-06", and "2023-01-07"
+

--- a/tests/testthat/_snaps/checkers.md
+++ b/tests/testthat/_snaps/checkers.md
@@ -1,0 +1,16 @@
+# Type-checking dates works
+
+    Code
+      check_date(not_dates, arg, call)
+    Condition
+      Error in `handlers[[1L]]()`:
+      ! `test` "abc" and "123" could not be automatically cast to date.
+      Try explicitly converting with `as.Date()`
+
+# Autofixing dates works as expected
+
+    Code
+      autofixed <- check_date(date_string, "potato")
+    Message
+      > Casting `potato` a string `2023-01-01` to a <Date> object "2023-01-01"
+

--- a/tests/testthat/_snaps/validate.md
+++ b/tests/testthat/_snaps/validate.md
@@ -1,0 +1,9 @@
+# `validate_dates()` is successful
+
+    Code
+      validate_dates(not_a_vector, "test")
+    Condition
+      Error in `throw_type_error()`:
+      ! `dates` is a list
+      i Must be of type Date
+

--- a/tests/testthat/test-RtGam.R
+++ b/tests/testthat/test-RtGam.R
@@ -33,3 +33,17 @@ test_that("Non-supported backends throw error", {
     class = "RtGam_invalid_input"
   )
 })
+
+test_that("Can autofix dates and fit model", {
+  timesteps <- 20
+  withr::with_seed(12345, {
+    cases <- rpois(20, 10)
+  })
+  dates <- as.Date("2023-01-01") + 1:timesteps
+  group <- NULL
+
+  expect_snapshot(
+    fit <- RtGam(cases, stringify_date(dates), group)
+  )
+  expect_s3_class(fit, "RtGam")
+})

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -219,11 +219,10 @@ test_that("Type-checking dates works", {
   arg <- "test"
   call <- NULL
 
-  expect_error(check_date(not_dates, arg, call),
-    class = "RtGam_type_error",
-    regexp = "Date"
+  expect_snapshot(check_date(not_dates, arg, call),
+    error = TRUE
   )
-  expect_null(check_date(dates, arg, call))
+  expect_equal(check_date(dates, arg, call), dates)
 })
 
 test_that("Type-checking vectors works", {
@@ -289,4 +288,14 @@ test_that("Type error throws successfully", {
     obj = throw_type_error(object, arg_name, expected_type, call),
     class = "RtGam_type_error"
   )
+})
+
+test_that("Autofixing dates works as expected", {
+  date_string <- "2023-01-01"
+  date_Date <- as.Date(date_string)
+
+  expect_snapshot(
+    autofixed <- check_date(date_string, "potato")
+  )
+  expect_equal(autofixed, date_Date)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,8 @@
+test_that("Dates are converted to strings", {
+  dates_string <- c("2023-01-01", "2023-01-02")
+  dates <- as.Date(dates_string)
+  expect_equal(stringify_date(dates), dates_string)
+
+  # Passes if not a `Date`
+  expect_equal(stringify_date(dates_string), dates_string)
+})

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -5,7 +5,10 @@ test_that("`validate()` is successful", {
   k <- 3
   m <- 1
 
-  expect_null(validate(cases, dates, groups, k, m))
+  expect_equal(
+    validate(cases, dates, groups, k, m),
+    dates
+  )
 })
 
 test_that("`validate_cases()` is successful", {
@@ -36,15 +39,15 @@ test_that("`validate_dates()` is successful", {
   has_missing <- c(dates, NA)
   not_a_vector <- list(dates)
 
-  expect_null(validate_dates(dates, "test"))
+  expect_equal(validate_dates(dates, "test"), dates)
   expect_error(validate_dates(not_dates, "test"),
     class = "RtGam_type_error"
   )
   expect_error(validate_dates(has_missing, "test"),
     class = "RtGam_invalid_input"
   )
-  expect_error(validate_dates(not_a_vector, "test"),
-    class = "RtGam_type_error"
+  expect_snapshot(validate_dates(not_a_vector, "test"),
+    error = TRUE
   )
 })
 


### PR DESCRIPTION
And print a helpful message when casting the dates. This is a small
change, but a nice quality-of-life improvement when specifying the
model.

This change breaks the pattern of checking & validating with empty
returns. I don't love breaking the pattern, but I thought the best
alternative would be to fully pull out the validators and have each
validator return their input. That might be worth it at some point,
but while we're only doing that for the dates I didn't think it was
worth it just yet.
