### PR TITLE
Cancel in-progress workflows on subsequent push

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,10 @@ on:
 
 name: R-CMD-check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/block-fixup.yaml
+++ b/.github/workflows/block-fixup.yaml
@@ -2,6 +2,10 @@ name: Git Checks
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   block-fixup:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-news-md.yaml
+++ b/.github/workflows/check-news-md.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-news-md-modification:
     runs-on: ubuntu-latest

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,6 +11,10 @@ on:
 
 name: pkgdown
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -8,6 +8,10 @@ on:
 
 name: test-coverage
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Added a Justfile with some common development tasks (#56)
 * Set up automated spellcheck (#61)
 * Add slash-command to update WORDLIST in a PR (#64)
+* Cancel in-progress GHA runs on subsequent push (#71)
 
 # RtGam v0.1.0
 


### PR DESCRIPTION
I often forget small things like updating NEWS before opening the PR.
I feel bad that I need to run all the checks each time when they could
be canceled.

This is my small fix.
