### PR TITLE
Allow wordlist update action to kickoff CI

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -86,6 +86,8 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Bugs
 
 * Drop old typos that snuck through the WORDLIST setup (#73)
+* Turn off credential caching in WORDLIST update action preventing CI from restarting (#74)
 
 ## Developer tooling
 


### PR DESCRIPTION
It's not using the specified credential because it's caching the
credential from the checkout. We want to use a different, more
privileged, credential for the push to re-start CI. This change
turns off the caching. See more here:
https://github.com/orgs/community/discussions/25172
