### PR TITLE
Temporarily drop Mac CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
 


### PR DESCRIPTION
Drop Mac CI runner while setup R/homebrew issue is resolved

NB: I think we can skip NEWS on this one