### PR TITLE
Remove Epinowcast Universe

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,7 +42,6 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-          extra-repositories: 'https://epinowcast.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,6 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          extra-repositories: 'https://epinowcast.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,6 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          extra-repositories: 'https://epinowcast.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,5 @@ Imports:
 Depends:
     R (>= 3.50)
 LazyData: true
-Additional_repositories:
-    https://epinowcast.r-universe.dev
 Language: en-US
 VignetteBuilder: knitr


### PR DESCRIPTION
As the title this PR closes #102 by removing all instances of the epinowcast universe. This means using the CRAN version of `primarycensored` vs the dev version.