### PR TITLE
Fix spurious diagnostic warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * Set up dev and release versions of pkgdown site (#101)
 
+## Bugs
+* Fix spurious diagnostic warnings when using a day-of-week effect (#104)
+
 # RtGam v0.3.0
 
 This release introduces support for modeling and correcting day-of-week effects in case reporting. It allows for default day-of-week detection or user-specified custom day-of-week levels, such as for holidays.

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -155,7 +155,7 @@ test_that("Warnings are issued for diagnostic failures", {
   # Wrapping in suppressMessages to catch all of multi-line warnings
   suppressMessages(expect_condition(
     issue_diagnostic_warnings(k_to_edf_ratio_high),
-    regexp = "Effective degrees of freedom is near the supplied upper bound"
+    regexp = "Effective degrees of freedom for one or more smooths near max"
   ))
   suppressMessages(expect_condition(
     issue_diagnostic_warnings(k_p_value_low),


### PR DESCRIPTION
Previous warnings were being thrown off by the addition of the day
of week effect. The parsing logic didn't handle multiple smooths.
I've now updated the logic and the warnings to make sense for the
case with multiple smooths. I also set it to ignore random effects.
