### PR TITLE
Bump line length linter to 100 chars

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,4 @@
 linters: linters_with_defaults(object_name_linter = NULL,
-                               object_usage_linter = NULL)
+                               object_usage_linter = NULL,
+                               line_length_linter(100))
 encoding: "UTF-8"

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Developer tooling
 * Add R installation to the pre-commit workflow, fixing the failures caused by the upgrade to the default Ubuntu runner (#112)
+* Relax the line length linter to 100 characters, from the default of 90 (#111)
 
 # RtGam v0.3.0
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -34,11 +34,11 @@ dev
 doi
 edf
 et
-gam
 geoms
 ggplot
 http
 https
+linter
 md
 medRxiv
 mgcv


### PR DESCRIPTION
From the default of 80. Follows the example from the docs on
[implementation](https://lintr.r-lib.org/articles/lintr.html#lintr-file-example).

Closes #109
